### PR TITLE
Updated bluebird to version 2.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "resolve"
   ],
   "dependencies": {
-    "bluebird": "2.10.1",
+    "bluebird": "2.10.2",
     "debug": "2.2.0",
     "filesize": "3.1.3",
     "hash": "0.2.0",


### PR DESCRIPTION
:rocket:

bluebird just published version 2.10.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/petkaantonov/bluebird/releases/tag/v2.10.2)

Features:

 - `.timeout()` now takes a custom error object as second argument

---
The new version differs by 12 commits (ahead by 12, behind by 0).

- [02c0fd2](https://github.com/petkaantonov/bluebird/commit/02c0fd252cf7c0c86e6b27bb06422c404829b539): Release v2.10.2
- [af326e8](https://github.com/petkaantonov/bluebird/commit/af326e82250fd632cfbb8f6a378379db2210c89d): added test, updated api docs
- [410b13e](https://github.com/petkaantonov/bluebird/commit/410b13ee876ee0728069b6b65f75ed6bf4dfd91a): Update timers.js
- [f5c167d](https://github.com/petkaantonov/bluebird/commit/f5c167dcd8bff9d5d276f8e8a53ac39d2edf6609): PR for 762
- [f33de7a](https://github.com/petkaantonov/bluebird/commit/f33de7a066fc0504dfd9d9b2f5e6f817191f6446): Merge pull request #779 from reggi/patch-3
- [658dd57](https://github.com/petkaantonov/bluebird/commit/658dd57f6ce4debad4115c17a9ef00a29b1f9c88): Merge pull request #787 from moretti/patch-2
- [c62180d](https://github.com/petkaantonov/bluebird/commit/c62180d50c51fece6d0e00bcebef9ec139e9da2e): Fix typo: later -> latter
- [4a3a43a](https://github.com/petkaantonov/bluebird/commit/4a3a43aeb95b54810b83a429199caa49d5b68a11): doc: typo paramter to parameter
- [4be7d79](https://github.com/petkaantonov/bluebird/commit/4be7d7921c9288730b991e19808317f5b91c5db5): Merge pull request #778 from reggi/patch-2
- [5a6f8be](https://github.com/petkaantonov/bluebird/commit/5a6f8bef67aa1806a61e4ac80becc614a436f658): Merge pull request #777 from reggi/patch-1
- [d13478d](https://github.com/petkaantonov/bluebird/commit/d13478d96cf9b270ff8770dd344e7ca65cc28e01): doc: typo peformance to performance
- [48ad33e](https://github.com/petkaantonov/bluebird/commit/48ad33e3a310133ac6d33cf7e0e9be35e9dbf7e4): doc: typo competetive to competitive

See the [full diff](https://github.com/petkaantonov/bluebird/compare/41b23cce935e77b851e076928745ad4c3cebba42...02c0fd252cf7c0c86e6b27bb06422c404829b539).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>